### PR TITLE
Added persistent node update to relative image paths

### DIFF
--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -19,10 +19,11 @@ export type GatsbyPluginArgs = {
 };
 
 export const onCreateNode = (
-  { node, getNodesByType }: GatsbyPluginArgs,
+  { node, getNodesByType, actions }: GatsbyPluginArgs,
   pluginOptions: PluginOptions
 ) => {
   const options = defaults(pluginOptions, defaultPluginOptions);
+  const { createNodeField } = actions;
 
   if (node.fileAbsolutePath && node.internal.type === `MarkdownRemark` || node.internal.type === `Mdx`) {
     const files = getNodesByType(`File`);
@@ -56,6 +57,12 @@ export const onCreateNode = (
       const newValue = slash(path.relative(directory, file.absolutePath));
 
       this.update(newValue);
+      
+      createNodeField({
+        node,
+        name: `frontmatter`,
+        value: node.frontmatter,
+      });
     });
   }
 };


### PR DESCRIPTION
Current solution only works in development build, which already had been addressed in various issues. The cause for the common "null" instead of image comes from in-memory node processing which does not persist throughout Gatsby build pipeline.